### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/emacs/speech-tagger.el
+++ b/emacs/speech-tagger.el
@@ -280,7 +280,10 @@ job-id off of `speech-tagger/*jobs*'"
     (if (not reg-log)
         (throw 'speech-tagger/no-such-job
                (format "%s %d %s" "no job with id" job-id "found"))
-      (cl-destructuring-bind (:beg beg :end end :buffer buf :text text) reg-log
+      (let ((beg (plist-get reg-log :beg))
+            (end (plist-get reg-log :end))
+            (buf (plist-get reg-log :buffer))
+            (text (plist-get reg-log :text)))
         (with-current-buffer buf
           (let ((cur-text (buffer-substring beg end)))
             (unless (equal text cur-text)
@@ -368,7 +371,7 @@ Apply widening with `speech-tagger/widen-region-to-word-bounds'."
         speech-tagger/*tag-proc-cur-line* ""
         speech-tagger/*jobs* nil
         speech-tagger/*pos-hash* nil)
-  (mapcar
+  (mapc
    (lambda (proc)
      (when (equal (buffer-name (process-buffer proc))
                   speech-tagger/+tag-proc-buf-name+)


### PR DESCRIPTION
I got following byte compile warnings.

```
In speech-tagger/process-tag-proc-json:
speech-tagger.el:283:31:Warning: attempt to let-bind constant `:beg`
speech-tagger.el:283:40:Warning: attempt to let-bind constant `:end`
speech-tagger.el:283:49:Warning: attempt to let-bind constant `:buffer`
speech-tagger.el:283:61:Warning: attempt to let-bind constant `:text`

In speech-tagger/clear-state:
speech-tagger.el:371:4:Warning: `mapcar' called for effect; use `mapc' or
    `dolist' instead
```
